### PR TITLE
Config for mulighetsrommet-api

### DIFF
--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -46,6 +46,9 @@ spec:
         - application: veilarbapi
           namespace: pto
           cluster: dev-gcp
+        - application: mulighetsrommet-api
+          namespace: team-mulighetsrommet
+          cluster: dev-gcp
   env:
     - name: VEILARBOPPFOLGING_URL
       value: http://veilarboppfolging.pto.svc.nais.local/veilarboppfolging

--- a/.nais/nais-prod.yaml
+++ b/.nais/nais-prod.yaml
@@ -46,6 +46,9 @@ spec:
         - application: veilarbapi
           namespace: pto
           cluster: prod-gcp
+        - application: mulighetsrommet-api
+          namespace: team-mulighetsrommet
+          cluster: prod-gcp
   env:
     - name: VEILARBOPPFOLGING_URL
       value: http://veilarboppfolging.pto.svc.nais.local/veilarboppfolging


### PR DESCRIPTION
Mulighetsrommet-api trenger å koble seg til veilarbarena og vil bruke poao-gcp-proxy for å gå fra gcp til fss. Oppsett for kobling i denne PR.